### PR TITLE
fix: Windows LaunchCmd

### DIFF
--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -28,7 +28,7 @@ func Run(ctx context.Context, cmd *cli.Command) error {
 	switch {
 	case game.LaunchCmd != "":
 		// Launch using platform-specific command
-		proc = exec.Command("cmd", "/C", "start", "", game.LaunchCmd)
+		proc = exec.Command("rundll32.exe", "url.dll,FileProtocolHandler", game.LaunchCmd)
 
 	case game.Executable != "":
 		// Launch directly from executable


### PR DESCRIPTION
<details>
<summary>The protocol handler wasn't working for me (likely due to the empty argument), also there's no reason to spawn an entire shell just to exec <code>FileProtocolHandler</code>.</summary>

```
[genie] [exec: "gameID": executable file not found in %PATH%]
```
</details>

The proper way to do this would be like https://zchee.github.io/golang-wiki/WindowsDLLs/. I'm not super familiar with Golang, so for now I just took this route (especially since I really dislike cgo, and have no real experience with the syscall package).